### PR TITLE
feat: Add one-click video analysis with structured output

### DIFF
--- a/backend/app/api_v1/endpoints/analysis.py
+++ b/backend/app/api_v1/endpoints/analysis.py
@@ -1,0 +1,148 @@
+"""Video analysis endpoint."""
+
+import json
+import logging
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlmodel import Session, select
+
+from app.api_v1.schemas import AnalysisRequest, AnalysisResponse
+from app.core.llm_config import get_current_provider
+from app.db.database import get_session
+from app.db.models import Video, VideoAnalysis
+from app.services.analysis import generate_analysis
+
+logger = logging.getLogger(__name__)
+router = APIRouter()
+
+
+@router.post("/{video_id}/analyze", response_model=AnalysisResponse)
+async def analyze_video(
+    video_id: str,
+    request: AnalysisRequest | None = None,
+    db: Session = Depends(get_session),
+):
+    video = db.get(Video, video_id)
+    if not video:
+        raise HTTPException(status_code=404, detail="Video not found")
+
+    if not video.transcript:
+        raise HTTPException(
+            status_code=400,
+            detail="Cannot analyze video without transcript",
+        )
+
+    force_regenerate = request.force_regenerate if request else False
+
+    if not force_regenerate:
+        cached = db.exec(
+            select(VideoAnalysis).where(VideoAnalysis.video_id == video_id)
+        ).first()
+
+        if cached:
+            logger.info(f"Returning cached analysis for {video_id}")
+            return AnalysisResponse(
+                video_id=video_id,
+                summary=cached.summary,
+                key_takeaways=json.loads(cached.key_takeaways),
+                main_topics=json.loads(cached.main_topics),
+                notable_quotes=json.loads(cached.notable_quotes),
+                model_used=cached.model_used,
+                created_at=cached.created_at,
+                cached=True,
+            )
+
+    video_info = {
+        "video_id": video.id,
+        "title": video.title,
+        "channel_title": video.channel_title,
+        "duration": video.duration,
+    }
+
+    provider = get_current_provider()
+    model_used = provider.model if provider else "unknown"
+
+    logger.info(f"Generating analysis for {video_id} using {model_used}")
+    analysis_output = await generate_analysis(video_info, video.transcript)
+
+    if force_regenerate:
+        existing = db.exec(
+            select(VideoAnalysis).where(VideoAnalysis.video_id == video_id)
+        ).first()
+        if existing:
+            db.delete(existing)
+            db.commit()
+
+    db_analysis = VideoAnalysis(
+        video_id=video_id,
+        summary=analysis_output.summary,
+        key_takeaways=json.dumps(analysis_output.key_takeaways),
+        main_topics=json.dumps(analysis_output.main_topics),
+        notable_quotes=json.dumps(analysis_output.notable_quotes),
+        model_used=model_used,
+    )
+    db.add(db_analysis)
+    db.commit()
+    db.refresh(db_analysis)
+
+    logger.info(f"Analysis saved for {video_id}")
+
+    return AnalysisResponse(
+        video_id=video_id,
+        summary=analysis_output.summary,
+        key_takeaways=analysis_output.key_takeaways,
+        main_topics=analysis_output.main_topics,
+        notable_quotes=analysis_output.notable_quotes,
+        model_used=model_used,
+        created_at=db_analysis.created_at,
+        cached=False,
+    )
+
+
+@router.get("/{video_id}/analysis", response_model=AnalysisResponse)
+async def get_analysis(
+    video_id: str,
+    db: Session = Depends(get_session),
+):
+    video = db.get(Video, video_id)
+    if not video:
+        raise HTTPException(status_code=404, detail="Video not found")
+
+    cached = db.exec(
+        select(VideoAnalysis).where(VideoAnalysis.video_id == video_id)
+    ).first()
+
+    if not cached:
+        raise HTTPException(
+            status_code=404,
+            detail="No analysis found. Use POST to generate.",
+        )
+
+    return AnalysisResponse(
+        video_id=video_id,
+        summary=cached.summary,
+        key_takeaways=json.loads(cached.key_takeaways),
+        main_topics=json.loads(cached.main_topics),
+        notable_quotes=json.loads(cached.notable_quotes),
+        model_used=cached.model_used,
+        created_at=cached.created_at,
+        cached=True,
+    )
+
+
+@router.delete("/{video_id}/analysis")
+async def delete_analysis(
+    video_id: str,
+    db: Session = Depends(get_session),
+):
+    cached = db.exec(
+        select(VideoAnalysis).where(VideoAnalysis.video_id == video_id)
+    ).first()
+
+    if not cached:
+        raise HTTPException(status_code=404, detail="No analysis found")
+
+    db.delete(cached)
+    db.commit()
+
+    return {"success": True, "message": "Analysis deleted"}

--- a/backend/app/api_v1/endpoints/videos.py
+++ b/backend/app/api_v1/endpoints/videos.py
@@ -19,7 +19,7 @@ from app.api_v1.schemas import (
 )
 from app.api_v1.schemas import Video as VideoSchema
 from app.db.database import get_engine, get_session
-from app.db.models import Chunk, SessionVideo, Video, utc_now
+from app.db.models import Chunk, SessionVideo, Video, VideoAnalysis, utc_now
 from app.db.models import Session as DBSession
 from app.services.embeddings import clear_model
 from app.services.export import export_json, export_markdown, export_srt, export_txt
@@ -396,13 +396,17 @@ async def export_transcript(
             media_type="text/srt; charset=utf-8",
         )
 
-    # JSON format - reuse chunks variable from SRT check if available, otherwise query
+    # JSON format - include chunks and analysis if available
     if format == ExportFormat.JSON:
         chunks = db.exec(
             select(Chunk).where(Chunk.video_id == video_id).order_by(Chunk.start_time)  # type: ignore[arg-type]
         ).all()
 
-    data = export_json(video, list(chunks) if chunks else None)
+    analysis = db.exec(
+        select(VideoAnalysis).where(VideoAnalysis.video_id == video_id)
+    ).first()
+
+    data = export_json(video, list(chunks) if chunks else None, analysis)
     return JSONResponse(
         data,
         headers={"Content-Disposition": f'attachment; filename="{filename}"'},

--- a/backend/app/api_v1/schemas.py
+++ b/backend/app/api_v1/schemas.py
@@ -123,3 +123,18 @@ class SessionDetailResponse(BaseModel):
     updated_at: datetime
     messages: list[MessageResponse]
     videos: list[SessionVideoResponse]
+
+
+class AnalysisRequest(BaseModel):
+    force_regenerate: bool = False
+
+
+class AnalysisResponse(BaseModel):
+    video_id: str
+    summary: str
+    key_takeaways: list[str]
+    main_topics: list[str]
+    notable_quotes: list[str]
+    model_used: str
+    created_at: datetime
+    cached: bool

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -82,3 +82,18 @@ class SessionVideo(SQLModel, table=True):
 
     session: Session = Relationship(back_populates="session_videos")
     video: Video = Relationship()
+
+
+class VideoAnalysis(SQLModel, table=True):
+    """Cached video analysis result."""
+
+    __tablename__ = "video_analysis"
+
+    id: str = Field(default_factory=lambda: str(uuid4()), primary_key=True)
+    video_id: str = Field(foreign_key="video.id", index=True, unique=True)
+    summary: str
+    key_takeaways: str
+    main_topics: str
+    notable_quotes: str
+    model_used: str
+    created_at: datetime = Field(default_factory=utc_now)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -4,7 +4,7 @@ from contextlib import asynccontextmanager
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
-from app.api_v1.endpoints import chat, sessions, settings, transcripts, videos
+from app.api_v1.endpoints import analysis, chat, sessions, settings, transcripts, videos
 from app.core.config import get_settings
 from app.core.llm_config import load_config
 from app.db.database import init_db
@@ -43,6 +43,9 @@ app.add_middleware(
 
 app.include_router(
     videos.router, prefix=f"{app_settings.api_v1_str}/videos", tags=["videos"]
+)
+app.include_router(
+    analysis.router, prefix=f"{app_settings.api_v1_str}/videos", tags=["analysis"]
 )
 app.include_router(
     transcripts.router,

--- a/backend/app/services/analysis.py
+++ b/backend/app/services/analysis.py
@@ -1,0 +1,141 @@
+"""Video analysis service using LLM structured output."""
+
+import json
+import logging
+from typing import Any
+
+import litellm
+from fastapi import HTTPException
+from litellm.exceptions import APIError, AuthenticationError, NotFoundError
+from pydantic import BaseModel, Field
+
+from app.core.llm_config import get_current_provider
+from app.services.rag import has_rag_data, retrieve_context_for_query
+
+logger = logging.getLogger(__name__)
+
+
+class AnalysisOutput(BaseModel):
+    summary: str = Field(
+        description="2-3 paragraph executive summary of the video content"
+    )
+    key_takeaways: list[str] = Field(
+        description="5-7 bullet points with the most important insights"
+    )
+    main_topics: list[str] = Field(description="3-5 main topics or themes discussed")
+    notable_quotes: list[str] = Field(
+        description="2-3 interesting or impactful quotes from the video"
+    )
+
+
+ANALYSIS_SYSTEM_PROMPT = """\
+You are an expert content analyst. Analyze YouTube video transcripts.
+
+Focus on:
+1. SUMMARY: 2-3 paragraph overview of content, arguments, and conclusions.
+2. KEY TAKEAWAYS: 5-7 actionable insights. Start each with an action verb.
+3. MAIN TOPICS: 3-5 central themes discussed.
+4. NOTABLE QUOTES: 2-3 impactful quotes representing key ideas.
+
+Be concise. If transcript is partial, acknowledge limitations.
+Do NOT include timestamps in quotes. If no notable quotes, return empty list."""
+
+
+def build_analysis_context(
+    video_info: dict[str, Any],
+    transcript: str | None,
+) -> str:
+    parts = [
+        f"Video Title: {video_info.get('title', 'Unknown')}",
+        f"Channel: {video_info.get('channel_title', 'Unknown')}",
+        f"Duration: {video_info.get('duration', 'Unknown')}",
+        "",
+    ]
+
+    video_id = video_info.get("video_id", "")
+    if video_id and has_rag_data(video_id):
+        rag_context = retrieve_context_for_query(
+            query="main topics key points summary important ideas",
+            video_ids=[video_id],
+            top_k=20,
+            max_tokens=8000,
+        )
+        if rag_context:
+            parts.append("Relevant excerpts from transcript:")
+            parts.append(rag_context)
+            return "\n".join(parts)
+
+    parts.append("Full transcript:")
+    if transcript:
+        if len(transcript) > 15000:
+            parts.append(transcript[:15000] + "\n\n[Transcript truncated...]")
+        else:
+            parts.append(transcript)
+    else:
+        parts.append("(No transcript available)")
+
+    return "\n".join(parts)
+
+
+async def generate_analysis(
+    video_info: dict[str, Any],
+    transcript: str | None,
+) -> AnalysisOutput:
+    provider = get_current_provider()
+    if not provider:
+        raise HTTPException(
+            status_code=503,
+            detail="No LLM provider configured. Check config.yaml and API keys.",
+        )
+
+    if not transcript:
+        raise HTTPException(
+            status_code=400,
+            detail="Cannot analyze video without transcript.",
+        )
+
+    context = build_analysis_context(video_info, transcript)
+
+    user_content = f"{context}\n\nAnalyze this video and provide structured insights."
+    messages = [
+        {"role": "system", "content": ANALYSIS_SYSTEM_PROMPT},
+        {"role": "user", "content": user_content},
+    ]
+
+    try:
+        response = await litellm.acompletion(
+            model=provider.model,
+            messages=messages,
+            api_key=provider.api_key,
+            response_format=AnalysisOutput,
+        )
+
+        content = response.choices[0].message.content
+        if not content:
+            raise HTTPException(status_code=502, detail="Empty response from LLM")
+
+        try:
+            data = json.loads(content)
+            return AnalysisOutput(**data)
+        except (json.JSONDecodeError, ValueError) as e:
+            logger.error(f"Failed to parse LLM response: {e}\nContent: {content[:500]}")
+            raise HTTPException(
+                status_code=502,
+                detail="LLM returned invalid JSON response",
+            ) from e
+
+    except AuthenticationError as e:
+        raise HTTPException(
+            status_code=401,
+            detail=f"Invalid API key for {provider.name}",
+        ) from e
+    except NotFoundError as e:
+        raise HTTPException(
+            status_code=404,
+            detail=f"Model '{provider.model}' not found. {e.message}",
+        ) from e
+    except APIError as e:
+        raise HTTPException(
+            status_code=502,
+            detail=f"{provider.name} error: {e.message}",
+        ) from e

--- a/backend/app/services/export.py
+++ b/backend/app/services/export.py
@@ -1,6 +1,6 @@
 """Transcript export formatters."""
 
-from app.db.models import Chunk, Video
+from app.db.models import Chunk, Video, VideoAnalysis
 
 
 def format_timestamp_srt(seconds: float) -> str:
@@ -66,8 +66,14 @@ def export_srt(chunks: list[Chunk]) -> str:
     return "\n".join(lines)
 
 
-def export_json(video: Video, chunks: list[Chunk] | None = None) -> dict:
+def export_json(
+    video: Video,
+    chunks: list[Chunk] | None = None,
+    analysis: VideoAnalysis | None = None,
+) -> dict:
     """Export as structured JSON."""
+    import json
+
     result: dict = {
         "video_id": video.id,
         "title": video.title,
@@ -88,5 +94,15 @@ def export_json(video: Video, chunks: list[Chunk] | None = None) -> dict:
             }
             for chunk in chunks
         ]
+
+    if analysis:
+        result["analysis"] = {
+            "summary": analysis.summary,
+            "key_takeaways": json.loads(analysis.key_takeaways),
+            "main_topics": json.loads(analysis.main_topics),
+            "notable_quotes": json.loads(analysis.notable_quotes),
+            "model_used": analysis.model_used,
+            "created_at": analysis.created_at.isoformat(),
+        }
 
     return result

--- a/backend/tests/test_analysis.py
+++ b/backend/tests/test_analysis.py
@@ -1,0 +1,185 @@
+"""Tests for video analysis service."""
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+from app.services.analysis import (
+    AnalysisOutput,
+    build_analysis_context,
+    generate_analysis,
+)
+
+
+class TestBuildAnalysisContext:
+    def test_builds_context_with_transcript(self):
+        video_info = {
+            "video_id": "test123",
+            "title": "Test Video",
+            "channel_title": "Test Channel",
+            "duration": "PT10M30S",
+        }
+        transcript = "This is the test transcript content."
+
+        with patch("app.services.analysis.has_rag_data", return_value=False):
+            context = build_analysis_context(video_info, transcript)
+
+        assert "Test Video" in context
+        assert "Test Channel" in context
+        assert "PT10M30S" in context
+        assert "This is the test transcript content." in context
+
+    def test_truncates_long_transcript(self):
+        video_info = {
+            "video_id": "test",
+            "title": "T",
+            "channel_title": "C",
+            "duration": "PT1M",
+        }
+        long_transcript = "x" * 20000
+
+        with patch("app.services.analysis.has_rag_data", return_value=False):
+            context = build_analysis_context(video_info, long_transcript)
+
+        assert "[Transcript truncated...]" in context
+        assert len(context) < 20000
+
+    def test_uses_rag_when_available(self):
+        video_info = {
+            "video_id": "test123",
+            "title": "T",
+            "channel_title": "C",
+            "duration": "PT1M",
+        }
+        transcript = "Full transcript here"
+
+        with patch("app.services.analysis.has_rag_data", return_value=True):
+            with patch(
+                "app.services.analysis.retrieve_context_for_query",
+                return_value="RAG excerpts",
+            ):
+                context = build_analysis_context(video_info, transcript)
+
+        assert "RAG excerpts" in context
+        assert "Full transcript here" not in context
+
+    def test_handles_missing_transcript(self):
+        video_info = {
+            "video_id": "test",
+            "title": "T",
+            "channel_title": "C",
+            "duration": "PT1M",
+        }
+
+        with patch("app.services.analysis.has_rag_data", return_value=False):
+            context = build_analysis_context(video_info, None)
+
+        assert "(No transcript available)" in context
+
+
+class TestGenerateAnalysis:
+    @pytest.mark.asyncio
+    async def test_generate_analysis_success(self):
+        video_info = {
+            "video_id": "test123",
+            "title": "Test Video",
+            "channel_title": "Test Channel",
+            "duration": "PT10M",
+        }
+        transcript = "This is a test transcript about machine learning."
+
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = json.dumps(
+            {
+                "summary": "This video covers machine learning basics.",
+                "key_takeaways": ["ML is powerful", "Start with basics"],
+                "main_topics": ["Machine Learning", "AI"],
+                "notable_quotes": ["AI will change everything"],
+            }
+        )
+
+        with patch("app.services.analysis.get_current_provider") as mock_provider:
+            mock_provider.return_value = MagicMock(
+                model="gemini/gemini-2.5-flash",
+                api_key="test-key",
+                name="Gemini",
+            )
+            with patch("app.services.analysis.has_rag_data", return_value=False):
+                with patch(
+                    "litellm.acompletion",
+                    new_callable=AsyncMock,
+                    return_value=mock_response,
+                ):
+                    result = await generate_analysis(video_info, transcript)
+
+        assert isinstance(result, AnalysisOutput)
+        assert "machine learning" in result.summary.lower()
+        assert len(result.key_takeaways) == 2
+        assert len(result.main_topics) == 2
+
+    @pytest.mark.asyncio
+    async def test_generate_analysis_no_provider(self):
+        with patch("app.services.analysis.get_current_provider", return_value=None):
+            with pytest.raises(HTTPException) as exc:
+                await generate_analysis({"video_id": "test"}, "transcript")
+
+        assert exc.value.status_code == 503
+        assert "No LLM provider" in exc.value.detail
+
+    @pytest.mark.asyncio
+    async def test_generate_analysis_no_transcript(self):
+        with patch("app.services.analysis.get_current_provider") as mock_provider:
+            mock_provider.return_value = MagicMock()
+            with pytest.raises(HTTPException) as exc:
+                await generate_analysis({"video_id": "test"}, None)
+
+        assert exc.value.status_code == 400
+        assert "without transcript" in exc.value.detail
+
+    @pytest.mark.asyncio
+    async def test_generate_analysis_invalid_json(self):
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "not valid json"
+
+        with patch("app.services.analysis.get_current_provider") as mock_provider:
+            mock_provider.return_value = MagicMock(
+                model="test", api_key="key", name="Test"
+            )
+            with patch("app.services.analysis.has_rag_data", return_value=False):
+                with patch(
+                    "litellm.acompletion",
+                    new_callable=AsyncMock,
+                    return_value=mock_response,
+                ):
+                    with pytest.raises(HTTPException) as exc:
+                        await generate_analysis({"video_id": "t"}, "transcript")
+
+        assert exc.value.status_code == 502
+        assert "invalid JSON" in exc.value.detail
+
+
+class TestAnalysisOutput:
+    def test_valid_analysis_output(self):
+        output = AnalysisOutput(
+            summary="Test summary",
+            key_takeaways=["Point 1", "Point 2"],
+            main_topics=["Topic A"],
+            notable_quotes=[],
+        )
+        assert output.summary == "Test summary"
+        assert len(output.key_takeaways) == 2
+
+    def test_analysis_output_from_json(self):
+        data = {
+            "summary": "Summary text",
+            "key_takeaways": ["A", "B", "C"],
+            "main_topics": ["X", "Y"],
+            "notable_quotes": ["Quote 1"],
+        }
+        output = AnalysisOutput(**data)
+        assert output.summary == "Summary text"
+        assert output.key_takeaways == ["A", "B", "C"]

--- a/backend/tests/test_analysis_endpoint.py
+++ b/backend/tests/test_analysis_endpoint.py
@@ -1,0 +1,223 @@
+"""Integration tests for analysis endpoint."""
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlmodel import Session, SQLModel, create_engine
+
+from app.db.database import get_session
+from app.db.models import Video, VideoAnalysis
+from app.main import app
+from app.services.analysis import AnalysisOutput
+
+
+@pytest.fixture
+def test_client():
+    engine = create_engine(
+        "sqlite:///file:test_analysis?mode=memory&cache=shared",
+        connect_args={"check_same_thread": False, "uri": True},
+    )
+    SQLModel.metadata.drop_all(engine)
+    SQLModel.metadata.create_all(engine)
+
+    def get_test_session():
+        with Session(engine) as session:
+            yield session
+
+    app.dependency_overrides[get_session] = get_test_session
+    client = TestClient(app)
+    yield client, engine
+    app.dependency_overrides.clear()
+    SQLModel.metadata.drop_all(engine)
+
+
+def create_video_with_transcript(engine) -> Video:
+    with Session(engine) as session:
+        video = Video(
+            id="test-video-123",
+            title="Test Video Title",
+            channel_id="ch123",
+            channel_title="Test Channel",
+            duration="PT15M30S",
+            published_at=datetime.now(UTC),
+            transcript="This is a test transcript about Python programming and AI.",
+            transcript_source="youtube",
+        )
+        session.add(video)
+        session.commit()
+        session.refresh(video)
+        return video
+
+
+def create_video_without_transcript(engine) -> Video:
+    with Session(engine) as session:
+        video = Video(
+            id="no-transcript-456",
+            title="Video Without Transcript",
+            channel_id="ch123",
+            channel_title="Test Channel",
+            duration="PT5M",
+            published_at=datetime.now(UTC),
+            transcript=None,
+        )
+        session.add(video)
+        session.commit()
+        session.refresh(video)
+        return video
+
+
+def create_cached_analysis(engine, video_id: str) -> VideoAnalysis:
+    with Session(engine) as session:
+        analysis = VideoAnalysis(
+            video_id=video_id,
+            summary="Cached summary about Python.",
+            key_takeaways='["Learn Python", "Practice daily"]',
+            main_topics='["Python", "Programming"]',
+            notable_quotes='["Code is poetry"]',
+            model_used="gemini/gemini-2.5-flash",
+        )
+        session.add(analysis)
+        session.commit()
+        session.refresh(analysis)
+        return analysis
+
+
+class TestAnalyzeVideo:
+    def test_analyze_video_success(self, test_client):
+        client, engine = test_client
+        video = create_video_with_transcript(engine)
+
+        mock_output = AnalysisOutput(
+            summary="Generated summary",
+            key_takeaways=["Point 1", "Point 2"],
+            main_topics=["Topic A"],
+            notable_quotes=["Quote 1"],
+        )
+
+        with patch("app.api_v1.endpoints.analysis.get_current_provider") as mock_prov:
+            mock_prov.return_value = MagicMock(model="gemini/gemini-2.5-flash")
+            with patch(
+                "app.api_v1.endpoints.analysis.generate_analysis",
+                new_callable=AsyncMock,
+                return_value=mock_output,
+            ):
+                response = client.post(f"/api/v1/videos/{video.id}/analyze")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["video_id"] == video.id
+        assert data["summary"] == "Generated summary"
+        assert data["key_takeaways"] == ["Point 1", "Point 2"]
+        assert data["cached"] is False
+
+    def test_analyze_video_returns_cached(self, test_client):
+        client, engine = test_client
+        video = create_video_with_transcript(engine)
+        create_cached_analysis(engine, video.id)
+
+        response = client.post(f"/api/v1/videos/{video.id}/analyze")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["summary"] == "Cached summary about Python."
+        assert data["cached"] is True
+
+    def test_analyze_video_force_regenerate(self, test_client):
+        client, engine = test_client
+        video = create_video_with_transcript(engine)
+        create_cached_analysis(engine, video.id)
+
+        mock_output = AnalysisOutput(
+            summary="New summary",
+            key_takeaways=["New point"],
+            main_topics=["New topic"],
+            notable_quotes=[],
+        )
+
+        with patch("app.api_v1.endpoints.analysis.get_current_provider") as mock_prov:
+            mock_prov.return_value = MagicMock(model="gemini/gemini-2.5-flash")
+            with patch(
+                "app.api_v1.endpoints.analysis.generate_analysis",
+                new_callable=AsyncMock,
+                return_value=mock_output,
+            ):
+                response = client.post(
+                    f"/api/v1/videos/{video.id}/analyze",
+                    json={"force_regenerate": True},
+                )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["summary"] == "New summary"
+        assert data["cached"] is False
+
+    def test_analyze_video_not_found(self, test_client):
+        client, _ = test_client
+        response = client.post("/api/v1/videos/nonexistent/analyze")
+
+        assert response.status_code == 404
+        assert "Video not found" in response.json()["detail"]
+
+    def test_analyze_video_no_transcript(self, test_client):
+        client, engine = test_client
+        video = create_video_without_transcript(engine)
+
+        response = client.post(f"/api/v1/videos/{video.id}/analyze")
+
+        assert response.status_code == 400
+        assert "without transcript" in response.json()["detail"]
+
+
+class TestGetAnalysis:
+    def test_get_cached_analysis(self, test_client):
+        client, engine = test_client
+        video = create_video_with_transcript(engine)
+        create_cached_analysis(engine, video.id)
+
+        response = client.get(f"/api/v1/videos/{video.id}/analysis")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["summary"] == "Cached summary about Python."
+        assert data["cached"] is True
+
+    def test_get_analysis_not_found(self, test_client):
+        client, engine = test_client
+        video = create_video_with_transcript(engine)
+
+        response = client.get(f"/api/v1/videos/{video.id}/analysis")
+
+        assert response.status_code == 404
+        assert "No analysis found" in response.json()["detail"]
+
+    def test_get_analysis_video_not_found(self, test_client):
+        client, _ = test_client
+        response = client.get("/api/v1/videos/nonexistent/analysis")
+
+        assert response.status_code == 404
+        assert "Video not found" in response.json()["detail"]
+
+
+class TestDeleteAnalysis:
+    def test_delete_analysis(self, test_client):
+        client, engine = test_client
+        video = create_video_with_transcript(engine)
+        create_cached_analysis(engine, video.id)
+
+        response = client.delete(f"/api/v1/videos/{video.id}/analysis")
+
+        assert response.status_code == 200
+        assert response.json()["success"] is True
+
+        get_response = client.get(f"/api/v1/videos/{video.id}/analysis")
+        assert get_response.status_code == 404
+
+    def test_delete_analysis_not_found(self, test_client):
+        client, engine = test_client
+        video = create_video_with_transcript(engine)
+
+        response = client.delete(f"/api/v1/videos/{video.id}/analysis")
+
+        assert response.status_code == 404

--- a/backend/tests/test_db_models.py
+++ b/backend/tests/test_db_models.py
@@ -1,8 +1,10 @@
 from datetime import datetime
 
+import pytest
+from sqlalchemy.exc import IntegrityError
 from sqlmodel import select
 
-from app.db.models import Chunk, Message, Session, SessionVideo, Video
+from app.db.models import Chunk, Message, Session, SessionVideo, Video, VideoAnalysis
 
 
 class TestSessionModel:
@@ -362,3 +364,72 @@ class TestMultipleRecords:
 
         result = db_session.exec(select(Session)).all()
         assert len(result) == 3
+
+
+class TestVideoAnalysisModel:
+    def test_create_video_analysis(self, db_session):
+        video = Video(
+            id="test123",
+            title="Test Video",
+            channel_id="ch123",
+            channel_title="Test Channel",
+            duration="PT10M",
+            published_at=datetime.now(),
+            transcript="Test transcript",
+        )
+        db_session.add(video)
+        db_session.commit()
+
+        analysis = VideoAnalysis(
+            video_id="test123",
+            summary="This is a test summary.",
+            key_takeaways='["Point 1", "Point 2"]',
+            main_topics='["Topic A"]',
+            notable_quotes='["Quote 1"]',
+            model_used="gemini/gemini-2.5-flash",
+        )
+        db_session.add(analysis)
+        db_session.commit()
+        db_session.refresh(analysis)
+
+        assert analysis.id is not None
+        assert analysis.video_id == "test123"
+        assert analysis.summary == "This is a test summary."
+        assert analysis.model_used == "gemini/gemini-2.5-flash"
+        assert analysis.created_at is not None
+
+    def test_video_analysis_unique_constraint(self, db_session):
+        video = Video(
+            id="test456",
+            title="Test Video",
+            channel_id="ch123",
+            channel_title="Test Channel",
+            duration="PT10M",
+            published_at=datetime.now(),
+        )
+        db_session.add(video)
+        db_session.commit()
+
+        analysis1 = VideoAnalysis(
+            video_id="test456",
+            summary="First",
+            key_takeaways="[]",
+            main_topics="[]",
+            notable_quotes="[]",
+            model_used="test",
+        )
+        db_session.add(analysis1)
+        db_session.commit()
+
+        analysis2 = VideoAnalysis(
+            video_id="test456",
+            summary="Second",
+            key_takeaways="[]",
+            main_topics="[]",
+            notable_quotes="[]",
+            model_used="test",
+        )
+        db_session.add(analysis2)
+
+        with pytest.raises(IntegrityError):
+            db_session.commit()

--- a/backend/tests/test_export.py
+++ b/backend/tests/test_export.py
@@ -7,7 +7,7 @@ from fastapi.testclient import TestClient
 from sqlmodel import Session, SQLModel, create_engine
 
 from app.db.database import get_session
-from app.db.models import Chunk, Video
+from app.db.models import Chunk, Video, VideoAnalysis
 from app.main import app
 from app.services.export import (
     export_json,
@@ -126,6 +126,23 @@ class TestExportJson:
         assert result["segments"][0]["start"] == 0.0
         assert result["segments"][0]["text"] == "Hello world."
 
+    def test_with_analysis(self, sample_video: Video):
+        analysis = VideoAnalysis(
+            video_id="test123",
+            summary="Test summary about the video.",
+            key_takeaways='["Takeaway 1", "Takeaway 2"]',
+            main_topics='["Topic A", "Topic B"]',
+            notable_quotes='["Quote 1"]',
+            model_used="gemini/gemini-2.5-flash",
+        )
+        result = export_json(sample_video, analysis=analysis)
+        assert "analysis" in result
+        assert result["analysis"]["summary"] == "Test summary about the video."
+        assert result["analysis"]["key_takeaways"] == ["Takeaway 1", "Takeaway 2"]
+        assert result["analysis"]["main_topics"] == ["Topic A", "Topic B"]
+        assert result["analysis"]["notable_quotes"] == ["Quote 1"]
+        assert result["analysis"]["model_used"] == "gemini/gemini-2.5-flash"
+
 
 class TestExportEndpoint:
     def test_export_not_found(self):
@@ -234,6 +251,51 @@ class TestExportEndpoint:
             data = response.json()
             assert data["video_id"] == "jsontest"
             assert data["title"] == "JSON Test Video"
+        finally:
+            app.dependency_overrides.clear()
+
+    def test_export_json_with_analysis(self):
+        engine = create_engine(
+            "sqlite:///file:test_json_analysis?mode=memory&cache=shared&uri=true",
+            connect_args={"check_same_thread": False},
+        )
+        SQLModel.metadata.create_all(engine)
+        with Session(engine) as session:
+            video = Video(
+                id="jsonanalysistest",
+                title="JSON Analysis Test",
+                channel_id="UC123",
+                channel_title="Test Channel",
+                description="",
+                duration="PT5M",
+                published_at=datetime(2024, 1, 15, 12, 0, 0, tzinfo=UTC),
+                transcript="Hello world.",
+                transcript_source="youtube",
+            )
+            session.add(video)
+            analysis = VideoAnalysis(
+                video_id="jsonanalysistest",
+                summary="Test summary.",
+                key_takeaways='["Point 1"]',
+                main_topics='["Topic A"]',
+                notable_quotes='["Quote"]',
+                model_used="gemini/gemini-2.5-flash",
+            )
+            session.add(analysis)
+            session.commit()
+
+        def override_session():
+            with Session(engine) as session:
+                yield session
+
+        app.dependency_overrides[get_session] = override_session
+        try:
+            response = client.get("/api/v1/videos/jsonanalysistest/export?format=json")
+            assert response.status_code == 200
+            data = response.json()
+            assert "analysis" in data
+            assert data["analysis"]["summary"] == "Test summary."
+            assert data["analysis"]["key_takeaways"] == ["Point 1"]
         finally:
             app.dependency_overrides.clear()
 

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,12 +1,13 @@
 "use client"
 
 import { useState, useEffect, useCallback } from "react"
-import { Copy, Check, Download } from "lucide-react"
+import { Copy, Check, Download, Sparkles, RefreshCw } from "lucide-react"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { SessionSidebar } from "@/components/session-sidebar"
+import { AnalysisCard } from "@/components/analysis-card"
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -15,6 +16,7 @@ import {
 } from "@/components/ui/dropdown-menu"
 import {
   Video,
+  VideoAnalysis,
   ExportFormat,
   fetchSession,
   fetchSessionVideos,
@@ -28,6 +30,8 @@ import {
   createSession,
   exportTranscript,
   copyTranscript,
+  analyzeVideo,
+  getAnalysis,
 } from "@/lib/api"
 
 interface ChatMessage {
@@ -66,6 +70,8 @@ export default function Home() {
   const [currentProvider, setCurrentProvider] = useState<LLMProvider | null>(null)
   const [initializing, setInitializing] = useState(true)
   const [copiedVideoId, setCopiedVideoId] = useState<string | null>(null)
+  const [videoAnalyses, setVideoAnalyses] = useState<Record<string, VideoAnalysis>>({})
+  const [analyzingVideo, setAnalyzingVideo] = useState<string | null>(null)
 
   const loadSession = useCallback(async (sid: string) => {
     try {
@@ -272,6 +278,37 @@ export default function Home() {
     }
   }
 
+  const handleAnalyze = async (videoId: string, forceRegenerate: boolean = false) => {
+    setAnalyzingVideo(videoId)
+    try {
+      const analysis = await analyzeVideo(videoId, forceRegenerate)
+      setVideoAnalyses(prev => ({ ...prev, [videoId]: analysis }))
+    } catch (error) {
+      console.error("Analysis failed:", error)
+    }
+    setAnalyzingVideo(null)
+  }
+
+  useEffect(() => {
+    const loadAnalyses = async () => {
+      for (const video of videos) {
+        if (video.status === "ready" && !videoAnalyses[video.id]) {
+          try {
+            const analysis = await getAnalysis(video.id)
+            if (analysis) {
+              setVideoAnalyses(prev => ({ ...prev, [video.id]: analysis }))
+            }
+          } catch (error) {
+            console.error(`Failed to load analysis for ${video.id}:`, error)
+          }
+        }
+      }
+    }
+    if (videos.length > 0) {
+      loadAnalyses()
+    }
+  }, [videos])
+
   const getStatusColor = (status: string) => {
     switch (status) {
       case "ready": return "text-green-600"
@@ -410,6 +447,20 @@ export default function Home() {
                                   <Button
                                     size="sm"
                                     variant="ghost"
+                                    onClick={() => handleAnalyze(video.id)}
+                                    disabled={analyzingVideo === video.id}
+                                    className="h-6 w-6 p-0"
+                                    title={videoAnalyses[video.id] ? "View analysis" : "Analyze video"}
+                                  >
+                                    {analyzingVideo === video.id ? (
+                                      <RefreshCw className="h-3 w-3 animate-spin" />
+                                    ) : (
+                                      <Sparkles className={`h-3 w-3 ${videoAnalyses[video.id] ? "text-yellow-500" : ""}`} />
+                                    )}
+                                  </Button>
+                                  <Button
+                                    size="sm"
+                                    variant="ghost"
                                     onClick={() => handleCopy(video.id)}
                                     className="h-6 w-6 p-0"
                                     title="Copy transcript"
@@ -461,7 +512,20 @@ export default function Home() {
               </Card>
             </div>
 
-            <div className="col-span-2 flex flex-col min-h-0">
+            <div className="col-span-2 flex flex-col min-h-0 gap-4">
+              {videos.filter(v => videoAnalyses[v.id]).length > 0 && (
+                <div className="space-y-0 max-h-[40%] overflow-y-auto">
+                  {videos.filter(v => videoAnalyses[v.id]).map(video => (
+                    <AnalysisCard
+                      key={video.id}
+                      analysis={videoAnalyses[video.id]}
+                      videoTitle={video.title}
+                      onRegenerate={() => handleAnalyze(video.id, true)}
+                      isRegenerating={analyzingVideo === video.id}
+                    />
+                  ))}
+                </div>
+              )}
               <Card className="flex-1 flex flex-col min-h-0">
                 <CardHeader className="pb-3">
                   <CardTitle className="text-lg">Chat</CardTitle>

--- a/frontend/components/analysis-card.tsx
+++ b/frontend/components/analysis-card.tsx
@@ -1,0 +1,123 @@
+"use client"
+
+import { useState } from "react"
+import { ChevronDown, ChevronUp, RefreshCw, Sparkles } from "lucide-react"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Button } from "@/components/ui/button"
+import { VideoAnalysis } from "@/lib/api"
+
+interface AnalysisCardProps {
+  analysis: VideoAnalysis
+  videoTitle: string
+  onRegenerate: () => void
+  isRegenerating: boolean
+}
+
+export function AnalysisCard({ analysis, videoTitle, onRegenerate, isRegenerating }: AnalysisCardProps) {
+  const [isExpanded, setIsExpanded] = useState(true)
+
+  const formatDate = (dateString: string) => {
+    return new Date(dateString).toLocaleDateString(undefined, {
+      month: "short",
+      day: "numeric",
+      hour: "2-digit",
+      minute: "2-digit",
+    })
+  }
+
+  return (
+    <Card className="mb-4">
+      <CardHeader className="pb-2">
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-2 min-w-0 flex-1">
+            <Sparkles className="h-4 w-4 text-yellow-500 shrink-0" />
+            <CardTitle className="text-base truncate">{videoTitle}</CardTitle>
+            {analysis.cached && (
+              <span className="text-xs text-muted-foreground shrink-0">
+                ({formatDate(analysis.created_at)})
+              </span>
+            )}
+          </div>
+          <div className="flex items-center gap-1 shrink-0">
+            <Button
+              size="sm"
+              variant="ghost"
+              onClick={onRegenerate}
+              disabled={isRegenerating}
+              className="h-7 px-2"
+              title="Regenerate analysis"
+            >
+              <RefreshCw className={`h-3 w-3 ${isRegenerating ? "animate-spin" : ""}`} />
+            </Button>
+            <Button
+              size="sm"
+              variant="ghost"
+              onClick={() => setIsExpanded(!isExpanded)}
+              className="h-7 px-2"
+            >
+              {isExpanded ? <ChevronUp className="h-4 w-4" /> : <ChevronDown className="h-4 w-4" />}
+            </Button>
+          </div>
+        </div>
+      </CardHeader>
+
+      {isExpanded && (
+        <CardContent className="space-y-4 pt-0">
+          <div>
+            <h4 className="font-medium text-sm mb-1">Summary</h4>
+            <p className="text-sm text-muted-foreground whitespace-pre-wrap">
+              {analysis.summary}
+            </p>
+          </div>
+
+          {analysis.key_takeaways.length > 0 && (
+            <div>
+              <h4 className="font-medium text-sm mb-1">Key Takeaways</h4>
+              <ul className="list-disc list-inside text-sm text-muted-foreground space-y-1">
+                {analysis.key_takeaways.map((takeaway, i) => (
+                  <li key={i}>{takeaway}</li>
+                ))}
+              </ul>
+            </div>
+          )}
+
+          {analysis.main_topics.length > 0 && (
+            <div>
+              <h4 className="font-medium text-sm mb-1">Main Topics</h4>
+              <div className="flex flex-wrap gap-1">
+                {analysis.main_topics.map((topic, i) => (
+                  <span
+                    key={i}
+                    className="px-2 py-0.5 bg-muted rounded-full text-xs"
+                  >
+                    {topic}
+                  </span>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {analysis.notable_quotes.length > 0 && (
+            <div>
+              <h4 className="font-medium text-sm mb-1">Notable Quotes</h4>
+              <div className="space-y-1">
+                {analysis.notable_quotes.map((quote, i) => (
+                  <blockquote
+                    key={i}
+                    className="border-l-2 border-muted pl-2 text-sm text-muted-foreground italic"
+                  >
+                    &ldquo;{quote}&rdquo;
+                  </blockquote>
+                ))}
+              </div>
+            </div>
+          )}
+
+          <div className="text-xs text-muted-foreground pt-2 border-t">
+            Generated with {analysis.model_used}
+          </div>
+        </CardContent>
+      )}
+    </Card>
+  )
+}

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -177,3 +177,47 @@ export async function copyTranscript(videoId: string): Promise<string> {
 
   return response.text()
 }
+
+export interface VideoAnalysis {
+  video_id: string
+  summary: string
+  key_takeaways: string[]
+  main_topics: string[]
+  notable_quotes: string[]
+  model_used: string
+  created_at: string
+  cached: boolean
+}
+
+export async function analyzeVideo(
+  videoId: string,
+  forceRegenerate: boolean = false
+): Promise<VideoAnalysis> {
+  const response = await fetch(`${API_BASE}/videos/${videoId}/analyze`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ force_regenerate: forceRegenerate }),
+  })
+
+  if (!response.ok) {
+    const error = await response.json()
+    throw new Error(error.detail || "Failed to analyze video")
+  }
+
+  return response.json()
+}
+
+export async function getAnalysis(videoId: string): Promise<VideoAnalysis | null> {
+  const response = await fetch(`${API_BASE}/videos/${videoId}/analysis`)
+
+  if (response.status === 404) {
+    return null
+  }
+
+  if (!response.ok) {
+    const error = await response.json()
+    throw new Error(error.detail || "Failed to get analysis")
+  }
+
+  return response.json()
+}


### PR DESCRIPTION
## Summary
- Add one-click video analysis generating structured summaries, key takeaways, topics, and quotes
- Uses LiteLLM structured JSON output for reliable parsing
- Caches analysis per-video in SQLite (not per-session)
- Includes analysis in JSON export

## Changes
- **Backend**: VideoAnalysis model, analysis service, API endpoints (POST/GET/DELETE)
- **Frontend**: AnalysisCard component, Sparkles button in video list

## Test plan
- [x] 178 backend tests passing
- [x] Black formatting passes
- [x] Ruff linting passes
- [x] Frontend builds successfully
- [x] Manual test: Click sparkles on video with transcript
- [x] Manual test: Verify cached analysis returns instantly
- [x] Manual test: Force regenerate works
- [x] Manual test: JSON export includes analysis

Closes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)