### PR TITLE
feat: Add proxy support for YouTube transcript fetching

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,3 +8,9 @@ YOUTUBE_API_KEY=your_youtube_api_key_here
 GEMINI_API_KEY=your_gemini_api_key_here
 # OPENAI_API_KEY=your_openai_api_key_here
 # ANTHROPIC_API_KEY=your_anthropic_api_key_here
+
+# Optional: Webshare rotating residential proxy credentials (paid, most reliable)
+# For free tier proxies, configure host/port in config.yaml instead
+# Sign up at https://www.webshare.io/
+# WEBSHARE_PROXY_USERNAME=your_webshare_username
+# WEBSHARE_PROXY_PASSWORD=your_webshare_password

--- a/README.md
+++ b/README.md
@@ -34,17 +34,17 @@ Then chat with AI about the content. Add more videos to build context across mul
 
 ## Features
 
-| Feature | Description |
-|---------|-------------|
-| **Pattern Analysis** | One-click structured extraction (summaries, tutorial notes) |
-| **Multi-Video Chat** | Ask questions across multiple videos simultaneously |
-| **RAG-Powered** | Semantic search finds relevant transcript sections automatically |
-| **Transcript Search** | Find specific moments with keyword highlighting |
-| **Export Transcripts** | Download as TXT, SRT, or JSON |
-| **Language Preferences** | Set preferred caption languages (drag to reorder priority) |
-| **Streaming Responses** | See AI responses appear in real-time |
-| **Whisper Fallback** | Auto-transcribe videos without captions |
-| **Session Management** | Organize videos into separate analysis sessions |
+| Feature                  | Description                                                      |
+|--------------------------|------------------------------------------------------------------|
+| **Pattern Analysis**     | One-click structured extraction (summaries, tutorial notes)      |
+| **Multi-Video Chat**     | Ask questions across multiple videos simultaneously              |
+| **RAG-Powered**          | Semantic search finds relevant transcript sections automatically |
+| **Transcript Search**    | Find specific moments with keyword highlighting                  |
+| **Export Transcripts**   | Download as TXT, SRT, or JSON                                    |
+| **Language Preferences** | Set preferred caption languages (drag to reorder priority)       |
+| **Streaming Responses**  | See AI responses appear in real-time                             |
+| **Whisper Fallback**     | Auto-transcribe videos without captions                          |
+| **Session Management**   | Organize videos into separate analysis sessions                  |
 
 ## Requirements
 
@@ -100,8 +100,62 @@ Everything is cached locally in an SQLite database for fast repeat access.
 
 ## Troubleshooting
 
-**"Could not retrieve a transcript for the video"**
-Your YouTube API key is likely rate-limited. Wait a few minutes or check [quota usage](https://console.cloud.google.com/apis/api/youtube.googleapis.com/quotas).
+### YouTube IP Blocking
+
+**"Could not retrieve a transcript"** / **"YouTube is blocking requests from your IP"**
+
+YouTube aggressively blocks automated transcript requests. This is a YouTube limitation, not a tool bug. Common causes:
+
+- **Too many requests** - YouTube rate-limits IPs that fetch many transcripts
+- **Cloud/VPN IPs** - Most cloud providers and popular VPNs are pre-blocked
+- **Datacenter IPs** - Residential IPs work better than datacenter IPs
+
+**Workarounds (in order of reliability):**
+
+| Solution              | Effort | Notes                                                               |
+|-----------------------|--------|---------------------------------------------------------------------|
+| **Wait 24-48h**       | None   | IP blocks often expire after a day or two                           |
+| **Whisper fallback**  | None   | Enable in config - transcribes audio directly (slower but reliable) |
+| **Different network** | Low    | Mobile hotspot, different WiFi, etc.                                |
+| **Residential proxy** | Medium | Rotating residential IPs bypass YouTube's blocking (see below)      |
+
+#### Whisper Fallback
+
+To enable Whisper fallback (recommended), ensure your `config.yaml` has:
+
+```yaml
+whisper:
+  fallback_enabled: true
+  model: base  # or 'tiny' for faster, 'small' for better quality
+```
+
+#### Proxy Setup (Recommended)
+
+For reliable transcript fetching, use a rotating residential proxy. YouTube actively blocks datacenter IPs (including the free Webshare proxies), so **rotating residential is the only reliable option**.
+
+**Webshare Rotating Residential (~$4/month for 1GB ≈ 6,000+ videos)**
+
+1. Sign up at [webshare.io](https://www.webshare.io/)
+2. Purchase a **Rotating Residential** plan (1GB is plenty for normal use)
+3. Go to **Rotating Residential** → **Proxy List**, select **"Rotating Proxy Endpoint"** as connection method
+4. Copy your **username** (e.g., `username-rotate`) and **password**
+5. Add to `config.yaml`:
+   ```yaml
+   proxy:
+     type: webshare_rotating
+   ```
+6. Add credentials to `.env`:
+   ```env
+   WEBSHARE_PROXY_USERNAME=your_username-rotate
+   WEBSHARE_PROXY_PASSWORD=your_password
+   ```
+7. Restart: `docker-compose restart backend`
+
+The backend logs will show `Using Webshare rotating residential proxy` when configured.
+
+> **Note:** Webshare's free tier provides datacenter proxies which YouTube typically blocks. The paid rotating residential proxies (~$4 for 1GB) are much more reliable as they use real home IP addresses from an 80M+ IP pool.
+
+### Other Issues
 
 **Whisper transcription is slow**
 Use a smaller model in `config.yaml`: `model: tiny` (fastest) or `model: small` (balanced).

--- a/backend/app/core/llm_config.py
+++ b/backend/app/core/llm_config.py
@@ -34,17 +34,29 @@ class TranscriptConfig:
     prefer_manual: bool = True
 
 
+@dataclass
+class ProxyConfig:
+    # For generic HTTP proxy (e.g., Webshare free with IP auth)
+    host: str | None = None
+    port: int | None = None
+    # For Webshare rotating residential (credentials from env)
+    type: str | None = None  # "webshare_rotating"
+    username: str | None = None  # from WEBSHARE_PROXY_USERNAME
+    password: str | None = None  # from WEBSHARE_PROXY_PASSWORD
+
+
 _providers: dict[str, LLMProvider] = {}
 _current_provider_id: str | None = None
 _default_provider_id: str | None = None
 _whisper_config: WhisperConfig = WhisperConfig()
 _rag_config: RagConfig = RagConfig()
 _transcript_config: TranscriptConfig = TranscriptConfig()
+_proxy_config: ProxyConfig = ProxyConfig()
 
 
 def load_config(config_path: str | Path = "config.yaml") -> None:
     global _providers, _current_provider_id, _default_provider_id
-    global _whisper_config, _rag_config, _transcript_config
+    global _whisper_config, _rag_config, _transcript_config, _proxy_config
 
     path = Path(config_path)
     if not path.exists():
@@ -101,6 +113,15 @@ def load_config(config_path: str | Path = "config.yaml") -> None:
         prefer_manual=transcript_cfg.get("prefer_manual", True),
     )
 
+    proxy_cfg = config.get("proxy", {})
+    _proxy_config = ProxyConfig(
+        host=proxy_cfg.get("host"),
+        port=proxy_cfg.get("port"),
+        type=proxy_cfg.get("type"),
+        username=os.environ.get("WEBSHARE_PROXY_USERNAME"),
+        password=os.environ.get("WEBSHARE_PROXY_PASSWORD"),
+    )
+
 
 def get_providers() -> list[LLMProvider]:
     return list(_providers.values())
@@ -134,3 +155,7 @@ def get_rag_config() -> RagConfig:
 
 def get_transcript_config() -> TranscriptConfig:
     return _transcript_config
+
+
+def get_proxy_config() -> ProxyConfig:
+    return _proxy_config

--- a/backend/app/services/youtube.py
+++ b/backend/app/services/youtube.py
@@ -7,14 +7,98 @@ from datetime import datetime
 from typing import Any
 
 from googleapiclient.discovery import build
+from requests import Session
 from youtube_transcript_api import YouTubeTranscriptApi
-from youtube_transcript_api._errors import NoTranscriptFound, TranscriptsDisabled
+from youtube_transcript_api._errors import (
+    NoTranscriptFound,
+    TranscriptsDisabled,
+    YouTubeDataUnparsable,
+)
+from youtube_transcript_api.proxies import GenericProxyConfig, WebshareProxyConfig
 
 from app.core.config import get_settings
-from app.core.llm_config import get_transcript_config, get_whisper_config
+from app.core.llm_config import (
+    get_proxy_config,
+    get_transcript_config,
+    get_whisper_config,
+)
 from app.services.chunking import TranscriptSegment
 
 logger = logging.getLogger(__name__)
+
+
+def _create_browser_session() -> Session:
+    """Create a requests session with browser-like headers.
+
+    YouTube's Innertube API fingerprints requests based on headers.
+    Using realistic browser headers reduces the chance of being blocked.
+    """
+    session = Session()
+    session.headers.update(
+        {
+            "User-Agent": (
+                "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+                "AppleWebKit/537.36 (KHTML, like Gecko) "
+                "Chrome/131.0.0.0 Safari/537.36"
+            ),
+            "Accept-Language": "en-US,en;q=0.9",
+            "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+            "Accept-Encoding": "gzip, deflate, br",
+            "DNT": "1",
+            "Connection": "keep-alive",
+            "Upgrade-Insecure-Requests": "1",
+            "Sec-Fetch-Dest": "document",
+            "Sec-Fetch-Mode": "navigate",
+            "Sec-Fetch-Site": "none",
+            "Sec-Fetch-User": "?1",
+            "Cache-Control": "max-age=0",
+        }
+    )
+    return session
+
+
+# Cached transcript API instance
+_transcript_api: YouTubeTranscriptApi | None = None
+
+
+def _get_transcript_api() -> YouTubeTranscriptApi:
+    """Get a YouTubeTranscriptApi instance, using Webshare proxy if configured."""
+    global _transcript_api
+    if _transcript_api is not None:
+        return _transcript_api
+
+    proxy_cfg = get_proxy_config()
+
+    # Priority 1: Webshare rotating residential proxy (paid, most reliable)
+    if (
+        proxy_cfg.type == "webshare_rotating"
+        and proxy_cfg.username
+        and proxy_cfg.password
+    ):
+        logger.info("Using Webshare rotating residential proxy for YouTube transcripts")
+        _transcript_api = YouTubeTranscriptApi(
+            proxy_config=WebshareProxyConfig(
+                proxy_username=proxy_cfg.username,
+                proxy_password=proxy_cfg.password,
+            )
+        )
+    # Priority 2: Generic HTTP proxy (e.g., Webshare free with IP auth)
+    elif proxy_cfg.host and proxy_cfg.port:
+        proxy_url = f"http://{proxy_cfg.host}:{proxy_cfg.port}"
+        logger.info(f"Using generic proxy for YouTube transcripts: {proxy_url}")
+        _transcript_api = YouTubeTranscriptApi(
+            proxy_config=GenericProxyConfig(
+                http_url=proxy_url,
+                https_url=proxy_url,
+            )
+        )
+    else:
+        # Fall back to browser-like session without proxy
+        session = _create_browser_session()
+        _transcript_api = YouTubeTranscriptApi(http_client=session)
+
+    return _transcript_api
+
 
 VALID_LANGUAGE_CODES = {
     "en",
@@ -254,7 +338,7 @@ class YouTubeService:
     def get_available_languages(self, video_id: str) -> list[LanguageInfo]:
         """Get list of available transcript languages for a video."""
         try:
-            ytt_api = YouTubeTranscriptApi()
+            ytt_api = _get_transcript_api()
             transcript_list = ytt_api.list(video_id)
 
             return [
@@ -325,7 +409,7 @@ class YouTubeService:
             logger.info(
                 f"Fetching transcript for {video_id}, languages={preferred_languages}"
             )
-            ytt_api = YouTubeTranscriptApi()
+            ytt_api = _get_transcript_api()
             transcript_list = ytt_api.list(video_id)
 
             transcript, available_languages = self._select_best_transcript(
@@ -364,8 +448,17 @@ class YouTubeService:
             logger.warning(f"Transcripts disabled for {video_id}")
         except NoTranscriptFound:
             logger.warning(f"No transcripts found for {video_id}")
+        except YouTubeDataUnparsable as e:
+            # This often means YouTube changed their response format or is blocking
+            logger.error(
+                f"YouTube response unparsable for {video_id} - "
+                f"may indicate API changes or soft blocking: {e}"
+            )
         except Exception as e:
-            logger.error(f"Error fetching transcript for {video_id}: {e}")
+            # Log the full exception type for debugging
+            logger.error(
+                f"Error fetching transcript for {video_id} ({type(e).__name__}): {e}"
+            )
 
         if use_whisper_fallback is None:
             use_whisper_fallback = get_whisper_config().fallback_enabled

--- a/backend/requirements-lint.txt
+++ b/backend/requirements-lint.txt
@@ -19,3 +19,4 @@ psutil>=5.9.0
 ruff>=0.8.0
 mypy>=1.13.0
 types-PyYAML
+types-requests

--- a/backend/tests/test_youtube_service.py
+++ b/backend/tests/test_youtube_service.py
@@ -4,12 +4,21 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+import app.services.youtube as youtube_module
 from app.services.youtube import (
     LanguageInfo,
     TranscriptResult,
     YouTubeService,
     validate_language_codes,
 )
+
+
+@pytest.fixture(autouse=True)
+def reset_transcript_api_cache():
+    """Reset the cached transcript API instance before each test."""
+    youtube_module._transcript_api = None
+    yield
+    youtube_module._transcript_api = None
 
 
 class TestValidateLanguageCodes:

--- a/config.yaml
+++ b/config.yaml
@@ -30,3 +30,15 @@ rag:
 transcripts:
   preferred_languages: ["en", "de", "fr", "es", "pt", "it", "nl", "pl", "ja", "ko", "zh"]
   prefer_manual: true
+
+# Proxy for YouTube transcript fetching (optional)
+# YouTube aggressively blocks automated requests - a residential proxy helps avoid this
+# See README.md for setup instructions
+# proxy:
+#   # Option 1: Generic HTTP proxy (e.g., Webshare free tier with IP authorization)
+#   # Note: Free datacenter proxies are usually blocked by YouTube
+#   # host: "1.2.3.4"
+#   # port: 7030
+#   #
+#   # Option 2: Webshare rotating residential (recommended) - set credentials in .env
+#   type: webshare_rotating

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,8 @@ services:
       - GEMINI_API_KEY=${GEMINI_API_KEY}
       - OPENAI_API_KEY=${OPENAI_API_KEY:-}
       - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY:-}
+      - WEBSHARE_PROXY_USERNAME=${WEBSHARE_PROXY_USERNAME:-}
+      - WEBSHARE_PROXY_PASSWORD=${WEBSHARE_PROXY_PASSWORD:-}
       - CACHE_DIR=/app/.cache
     volumes:
       - ./backend:/app


### PR DESCRIPTION
YouTube aggressively blocks automated transcript requests, especially from datacenter IPs, cloud providers, and VPNs. This adds configurable proxy support to work around these blocks.

Changes:
- Add ProxyConfig to llm_config.py for proxy settings from config.yaml
- Support two proxy modes:
  1. Generic HTTP proxy (host/port in config.yaml)
  2. Webshare rotating residential (type + credentials in .env)
- Add browser-like headers as fallback when no proxy configured
- Update README with troubleshooting guide and proxy setup instructions
- Update .env.example and docker-compose.yml for proxy credentials

The rotating residential proxy (~$4/GB) is the most reliable option as it uses real home IP addresses from an 80M+ pool that YouTube doesn't block.

